### PR TITLE
Добавить Telegram-канал «Шайтан-Арба»

### DIFF
--- a/content.json
+++ b/content.json
@@ -153,6 +153,10 @@
   ],
   "telegram_channels": [
     {
+  "label": "Шайтан-Арба",
+  "value": "https://t.me/shaitan_arba_KG"
+},
+    {
       "label": "Data Engineer Jobs KG",
       "value": "https://t.me/datajobskg"
     },


### PR DESCRIPTION
Добавлен Telegram-канал «Шайтан-Арба» об искусственном интеллекте, технологиях и глобальных сдвигах.

Ссылка: https://t.me/shaitan_arba_KG